### PR TITLE
zmena projektoveho zvirete

### DIFF
--- a/seznam_ucastniku.md
+++ b/seznam_ucastniku.md
@@ -5,5 +5,5 @@
 Brenda Tomčalová Dasypus Novemcinctus
 Filip Sedlák Canis Lupus
 Dieu Hien Ho Ochotona Princeps
-Vojta Tláskal Myotis Lucifugus
+Vojta Tláskal Sarcophilus harrisii 
 ```


### PR DESCRIPTION
u M. lucifugus byl stazeny genom v jinem fomrmatu nez ostatni, nefungovala pro nej pocatecni uprava sloupcu, nejspis problem se zadanim dtype={0:np.object})